### PR TITLE
Make dataDir required on config

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,13 +7,8 @@ type Config struct {
 	limitNormalizeNode int
 }
 
-func NewDefaultConfig() Config {
-	return Config{limitNormalizeNode: 10000}
-}
-
-func (cc Config) WithDataDir(dir string) Config {
-	cc.dataDir = dir
-	return cc
+func NewDefaultConfig(dir string) Config {
+	return Config{dataDir: dir, limitNormalizeNode: 10000}
 }
 
 func (cc Config) WithLimitNormalizeNode(n int) Config {

--- a/db_test.go
+++ b/db_test.go
@@ -16,7 +16,7 @@ import (
 func TestRestart(t *testing.T) {
 	dataDir := t.TempDir()
 
-	db, err := modusdb.New(modusdb.NewDefaultConfig().WithDataDir(dataDir))
+	db, err := modusdb.New(modusdb.NewDefaultConfig(dataDir))
 	require.NoError(t, err)
 	defer func() { db.Close() }()
 
@@ -47,7 +47,7 @@ func TestRestart(t *testing.T) {
 	require.JSONEq(t, `{"me":[{"name":"A"}]}`, string(qresp.GetJson()))
 
 	db.Close()
-	db, err = modusdb.New(modusdb.NewDefaultConfig().WithDataDir(dataDir))
+	db, err = modusdb.New(modusdb.NewDefaultConfig(dataDir))
 	require.NoError(t, err)
 	qresp, err = db.Query(context.Background(), query)
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestRestart(t *testing.T) {
 }
 
 func TestSchemaQuery(t *testing.T) {
-	db, err := modusdb.New(modusdb.NewDefaultConfig().WithDataDir(t.TempDir()))
+	db, err := modusdb.New(modusdb.NewDefaultConfig(t.TempDir()))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -86,7 +86,7 @@ func TestBasicVector(t *testing.T) {
 	}
 	vectBytes := buf.Bytes()
 
-	db, err := modusdb.New(modusdb.NewDefaultConfig().WithDataDir(t.TempDir()))
+	db, err := modusdb.New(modusdb.NewDefaultConfig(t.TempDir()))
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/live_test.go
+++ b/live_test.go
@@ -42,7 +42,7 @@ func TestLiveLoaderSmall(t *testing.T) {
 		`
 	)
 
-	db, err := modusdb.New(modusdb.NewDefaultConfig().WithDataDir(t.TempDir()))
+	db, err := modusdb.New(modusdb.NewDefaultConfig(t.TempDir()))
 	require.NoError(t, err)
 	defer func() { db.Close() }()
 
@@ -83,7 +83,7 @@ func TestLiveLoaderSmall(t *testing.T) {
 }
 
 func TestLiveLoader1Million(t *testing.T) {
-	db, err := modusdb.New(modusdb.NewDefaultConfig().WithDataDir(t.TempDir()))
+	db, err := modusdb.New(modusdb.NewDefaultConfig(t.TempDir()))
 	require.NoError(t, err)
 	defer func() { db.Close() }()
 

--- a/vector_test.go
+++ b/vector_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 func TestVectorDelete(t *testing.T) {
-	db, err := modusdb.New(modusdb.NewDefaultConfig().WithDataDir(t.TempDir()))
+	db, err := modusdb.New(modusdb.NewDefaultConfig(t.TempDir()))
 	require.NoError(t, err)
 	defer func() { db.Close() }()
 


### PR DESCRIPTION
This PR removes the WithDataDir() function, which implies that the datadirectory is optional and enforces it on NewDefaultConfig, since on its own, the NewDefaultConfig will not spin up a new modusDB instance. Addressed in
https://linear.app/hypermode/issue/DGR-822/modusdb-newdefaultconfig-fails