### PR TITLE
use pinned hash in ci-go-lint

### DIFF
--- a/.github/workflows/ci-go-lint.yaml
+++ b/.github/workflows/ci-go-lint.yaml
@@ -29,6 +29,6 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.1.1
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout=10m


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

**Description**

Code scanning requires using pinned hashes on ci actions, so using v6 of go lint