### PR TITLE
chore: move to Warp runners for GitHub Actions

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - warp-ubuntu-latest-arm64-2x
+    - warp-ubuntu-latest-arm64-16x

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -2,4 +2,4 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
     - warp-ubuntu-latest-arm64-2x
-    - warp-ubuntu-latest-arm64-16x
+    - warp-ubuntu-latest-arm64-4x

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable first-line-heading -->
-
 **Description**
 
 Please explain the changes you made here.

--- a/.github/workflows/ci-go-lint.yaml
+++ b/.github/workflows/ci-go-lint.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   ci-go-lint:
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-arm64-2x
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-go-lint.yaml
+++ b/.github/workflows/ci-go-lint.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - "**/*.go"
       - "**/go.mod"
+      - .github/workflows/*
 
 permissions:
   contents: read

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - "**/*.go"
       - "**/go.mod"
+      - .github/workflows/*
 
 permissions:
   contents: read

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   ci-go-tests:
-    runs-on: warp-ubuntu-latest-arm64-16x
+    runs-on: warp-ubuntu-latest-arm64-4x
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   ci-go-tests:
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-arm64-16x
 
     steps:
       - uses: actions/checkout@v4

--- a/.trunk/configs/.markdownlint.json
+++ b/.trunk/configs/.markdownlint.json
@@ -3,5 +3,6 @@
   "no-inline-html": false,
   "no-bare-urls": false,
   "no-space-in-emphasis": false,
-  "no-emphasis-as-heading": false
+  "no-emphasis-as-heading": false,
+  "first-line-heading": false
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable first-line-heading -->
 <div align="center">
 
 [![modus](https://github.com/user-attachments/assets/1a6020bd-d041-4dd0-b4a9-ce01dc015b65)](https://github.com/hypermodeinc/modusdb)


### PR DESCRIPTION
**Description**

Move GitHub Actions workflows to Warp runners for faster tests through larger machine access.

**Checklist**

- [X] Code compiles correctly and linting passes locally