### PR TITLE
chore: Ignore blev warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/agnivade/levenshtein v1.0.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.17.0 // indirect
+	// trunk-ignore(osv-scanner/GHSA-9w9f-6mg8-jp7w)
 	github.com/blevesearch/bleve/v2 v2.4.3 // indirect
 	github.com/blevesearch/bleve_index_api v1.1.12 // indirect
 	github.com/blevesearch/geo v0.1.20 // indirect


### PR DESCRIPTION
This tells Trunk to ignore this issue raised by osv-scanner.

Details of the issue are here:
https://github.com/blevesearch/bleve/security/advisories/GHSA-9w9f-6mg8-jp7w

It's safe to ignore the issue, as we do not consume the `bleve/http` pacakge.