### PR TITLE
chore: update CI workflows

### DIFF
--- a/.github/workflows/ci-go-lint.yaml
+++ b/.github/workflows/ci-go-lint.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: 1.23.4
           cache-dependency-path: go.sum
 
       - name: golangci-lint

--- a/.github/workflows/ci-go-load-tests.yaml
+++ b/.github/workflows/ci-go-load-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: 1.23.4
           cache-dependency-path: go.sum
 
       - name: Run Unit Tests

--- a/.github/workflows/ci-go-unit-tests.yaml
+++ b/.github/workflows/ci-go-unit-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: 1.23.4
           cache-dependency-path: go.sum
 
       - name: Run Unit Tests

--- a/.github/workflows/ci-go-unit-tests.yaml
+++ b/.github/workflows/ci-go-unit-tests.yaml
@@ -21,12 +21,12 @@ jobs:
     name: Test ${{ matrix.os }}
     runs-on:
       "${{ matrix.os == 'linux' && 'warp-ubuntu-latest-x64-4x' || matrix.os == 'macos' &&
-      'warp-macos-15-arm64-6x' || 'warp-windows-latest-x64-4x' }}"
+      'warp-macos-15-arm64-6x' }}"
 
     strategy:
       fail-fast: false
       matrix:
-        os: [linux, macos, windows]
+        os: [linux, macos]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-go-unit-tests.yaml
+++ b/.github/workflows/ci-go-unit-tests.yaml
@@ -18,7 +18,15 @@ permissions:
 
 jobs:
   ci-go-tests:
-    runs-on: warp-ubuntu-latest-arm64-4x
+    name: Test ${{ matrix.os }}
+    runs-on:
+      "${{ matrix.os == 'linux' && 'warp-ubuntu-latest-x64-4x' || matrix.os == 'macos' &&
+      'warp-macos-15-arm64-6x' || 'warp-windows-latest-x64-4x' }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [linux, macos, windows]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Use Go 1.23.4 in workflows (note, `go-version-file` doesn't respect `toolchain`. See https://github.com/actions/setup-go/issues/457)
- Run unit tests on Linux, macOS, and Windows to ensure compatibility with supported Modus platforms.
