### PR TITLE
fix: check for valid schema before querying by constrained field

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -16,7 +16,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.23.3
+    - go@1.24.0
     - node@18.20.5
     - python@3.10.8
 


### PR DESCRIPTION
**Description**
This PR fixes #74. If querying (modusDB.Get) for a struct's constrained field before the schema contained that type, the worker would panic (the bug contains that trace). This change ensures the schema contains the type before  launching the query. Note that querying by uid does not suffer from this issue as the discovery of the tablets (groups) are not involved in the query.

Also added tests (as well as expanding existing unit tests) and changed the api file to use errors.New instead of the fmt package as no formatting was being applied.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
