### PR TITLE
Add cleanup func for returning dgo client to pool

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -261,8 +261,9 @@ func TestVectorSimilaritySearch(t *testing.T) {
 			vectorVar := "[0.51, 0.39, 0.29, 0.19, 0.09]"
 			query := dg.NewQuery().Model(&testItem).RootFunc("similar_to(vector, 1, $vec)")
 
-			dgo, err := client.DgraphClient()
+			dgo, cleanup, err := client.DgraphClient()
 			require.NoError(t, err)
+			defer cleanup()
 			tx := dg.NewReadOnlyTxn(dgo)
 			err = tx.Query(query).Vars("similar_to($vec: string)", map[string]string{"$vec": vectorVar}).Scan()
 			require.NoError(t, err)


### PR DESCRIPTION
**Description**

This PR adds a cleanup func to the return signature of client.DgraphClient. Needed to properly return the dgo client to the pool. This doesn't effect file-based instances, just those that work with remote clusters.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

